### PR TITLE
deleted 'showCoverageOnHover: false

### DIFF
--- a/MINeS.html
+++ b/MINeS.html
@@ -108,7 +108,6 @@
             }).on('ready', function() {
                 map.fitBounds(points.getBounds());
                 var markers = L.markerClusterGroup({
-                    showCoverageOnHover: true,
                     maxClusterRadius: 50
                 });
                 markers.addLayer(points);


### PR DESCRIPTION
coverage on hover is default according to mavrkercluster github, so
deleting calling it false should activate it
